### PR TITLE
fix: links preview of review text

### DIFF
--- a/newtab/index.tsx
+++ b/newtab/index.tsx
@@ -90,7 +90,7 @@ function NewTab() {
             </div>
 
             <div className='text-xl leading-relaxed text-center font-medium relative font-serif-eng ' >
-              <div dangerouslySetInnerHTML={{ __html: renderTextWithLinks(currentReview.text) }} />
+              <div className='markdown-rendered' dangerouslySetInnerHTML={{ __html: renderTextWithLinks(currentReview.text) }} />
               <div className=' text-base/50 text-sm mt-12 italic text-center top-[12px] left-[500px] w-[320px]'>
                 {currentReview.note}
               </div>

--- a/newtab/index.tsx
+++ b/newtab/index.tsx
@@ -42,11 +42,20 @@ function NewTab() {
 
   const currentReview = review.data?.highlights[random]
 
+  const renderTextWithLinks = (text) => {
+    const regex = /\[([^\]]+)\]\((https?:\/\/[^\s]+)\)/g
+    return text.replace(
+      regex,
+      (match, label, url) =>
+        `<a href="${url}" target="_blank" rel="noopener noreferrer" class="link-style">${label}</a>`
+    )
+  }
+
   return (
     <div>
       <nav className='p-3 px-6 flex justify-end'>
         <div className='flex gap-3 items-center'>
-         
+
           <div>
             <select className='select select-xs' data-choose-theme>
               {themes.map(theme => {
@@ -80,9 +89,7 @@ function NewTab() {
             </div>
 
             <div className='text-xl leading-relaxed text-center font-medium relative font-serif-eng ' >
-              <div>
-                {currentReview.text}
-              </div>
+              <div dangerouslySetInnerHTML={{ __html: renderTextWithLinks(currentReview.text) }} />
               <div className=' text-base/50 text-sm mt-12 italic text-center top-[12px] left-[500px] w-[320px]'>
                 {currentReview.note}
               </div>

--- a/newtab/index.tsx
+++ b/newtab/index.tsx
@@ -13,9 +13,17 @@ import { themeChange } from 'theme-change'
 import MarkdownIt from 'markdown-it';
 import DOMPurify from 'dompurify';
 
-const md = new MarkdownIt();
-
 function NewTab() {
+  const md = new MarkdownIt();
+  md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
+    const aIndex = tokens[idx].attrIndex('class');
+    if (aIndex < 0) {
+      tokens[idx].attrPush(['class', 'link link-primary']);
+    } else {
+      tokens[idx].attrs[aIndex][1] += ' link link-primary';
+    }
+    return self.renderToken(tokens, idx, options);
+  };
 
   const review = useQuery({
     queryKey: ['dailyReview'],
@@ -90,7 +98,7 @@ function NewTab() {
             </div>
 
             <div className='text-xl leading-relaxed text-center font-medium relative font-serif-eng ' >
-              <div className='markdown-rendered' dangerouslySetInnerHTML={{ __html: renderTextWithLinks(currentReview.text) }} />
+              <div dangerouslySetInnerHTML={{ __html: renderTextWithLinks(currentReview.text) }} />
               <div className=' text-base/50 text-sm mt-12 italic text-center top-[12px] left-[500px] w-[320px]'>
                 {currentReview.note}
               </div>

--- a/newtab/index.tsx
+++ b/newtab/index.tsx
@@ -10,6 +10,10 @@ import { Providers } from '~components/Providers'
 import { LuSettings } from 'react-icons/lu'
 import { themes } from '~themes'
 import { themeChange } from 'theme-change'
+import MarkdownIt from 'markdown-it';
+import DOMPurify from 'dompurify';
+
+const md = new MarkdownIt();
 
 function NewTab() {
 
@@ -43,12 +47,9 @@ function NewTab() {
   const currentReview = review.data?.highlights[random]
 
   const renderTextWithLinks = (text) => {
-    const regex = /\[([^\]]+)\]\((https?:\/\/[^\s]+)\)/g
-    return text.replace(
-      regex,
-      (match, label, url) =>
-        `<a href="${url}" target="_blank" rel="noopener noreferrer" class="link-style">${label}</a>`
-    )
+    const renderedText = md.render(text);
+    const sanitizedText = DOMPurify.sanitize(renderedText);
+    return sanitizedText;
   }
 
   return (

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "autoprefixer": "^10.4.19",
     "classnames": "^2.5.1",
     "daisyui": "^4.10.2",
+    "dompurify": "^3.1.0",
+    "markdown-it": "^14.1.0",
     "plasmo": "0.85.2",
     "postcss": "^8.4.38",
     "react": "18.2.0",
@@ -37,7 +39,6 @@
     "permissions": [
       "alarms"
     ],
-    "host_permissions": [
-    ]
+    "host_permissions": []
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ dependencies:
   daisyui:
     specifier: ^4.10.2
     version: 4.10.2(postcss@8.4.38)
+  dompurify:
+    specifier: ^3.1.0
+    version: 3.1.0
+  markdown-it:
+    specifier: ^14.1.0
+    version: 14.1.0
   plasmo:
     specifier: 0.85.2
     version: 0.85.2(postcss@8.4.38)(react-dom@18.2.0)(react@18.2.0)
@@ -3478,6 +3484,10 @@ packages:
       domelementtype: 2.3.0
     dev: false
 
+  /dompurify@3.1.0:
+    resolution: {integrity: sha512-yoU4rhgPKCo+p5UrWWWNKiIq+ToGqmVVhk0PmMYBK4kRsR3/qhemNFL8f6CFmBd4gMwm3F4T7HBoydP5uY07fA==}
+    dev: false
+
   /domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
     dependencies:
@@ -4441,6 +4451,12 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: false
 
+  /linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+    dependencies:
+      uc.micro: 2.1.0
+    dev: false
+
   /lmdb@2.5.2:
     resolution: {integrity: sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==}
     requiresBuild: true
@@ -4547,12 +4563,28 @@ packages:
     dev: false
     optional: true
 
+  /markdown-it@14.1.0:
+    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+    dev: false
+
   /mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
     dev: false
 
   /mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+    dev: false
+
+  /mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
     dev: false
 
   /merge-stream@2.0.0:
@@ -5149,6 +5181,11 @@ packages:
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
+    dev: false
+
+  /punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
     dev: false
 
   /punycode@2.3.1:
@@ -5839,6 +5876,10 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
+
+  /uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+    dev: false
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}

--- a/style.css
+++ b/style.css
@@ -18,13 +18,3 @@ body {
   font-size: 16px;
   @apply antialiased;
 }
-
-.link-style {
-  color: #007bff;
-  text-decoration: underline;
-}
-
-.link-style:hover {
-  color: #0056b3;
-  text-decoration: none;
-}

--- a/style.css
+++ b/style.css
@@ -18,3 +18,13 @@ body {
   font-size: 16px;
   @apply antialiased;
 }
+
+.link-style {
+  color: #007bff;
+  text-decoration: underline;
+}
+
+.link-style:hover {
+  color: #0056b3;
+  text-decoration: none;
+}

--- a/style.css
+++ b/style.css
@@ -18,14 +18,3 @@ body {
   font-size: 16px;
   @apply antialiased;
 }
-
-.markdown-rendered a {
-  color: #3498db;
-  text-decoration: underline;
-  transition: color 0.3s ease;
-}
-
-.markdown-rendered a:hover {
-  color: #0056b3;
-  text-decoration: none;
-}

--- a/style.css
+++ b/style.css
@@ -18,3 +18,14 @@ body {
   font-size: 16px;
   @apply antialiased;
 }
+
+.markdown-rendered a {
+  color: #3498db;
+  text-decoration: underline;
+  transition: color 0.3s ease;
+}
+
+.markdown-rendered a:hover {
+  color: #0056b3;
+  text-decoration: none;
+}


### PR DESCRIPTION
When daily review text has links, it will show the markdown syntax like:

![link_preview_before](https://github.com/djyde/wisetab/assets/69753389/2dc08d48-31c9-4880-9927-a572d8fa7e8e)

this pr fixes it using markdown-it and fits well in all themes using daisy-ui.

![link_preview_after](https://github.com/djyde/wisetab/assets/69753389/b8ef17e3-e149-4b6d-9928-9ee0709a0b60)
