### PR TITLE
fix: note display too left

### DIFF
--- a/newtab/index.tsx
+++ b/newtab/index.tsx
@@ -99,7 +99,7 @@ function NewTab() {
 
             <div className='text-xl leading-relaxed text-center font-medium relative font-serif-eng ' >
               <div dangerouslySetInnerHTML={{ __html: renderTextWithLinks(currentReview.text) }} />
-              <div className=' text-base/50 text-sm mt-12 italic text-center top-[12px] left-[500px] w-[320px]'>
+              <div className=' text-base/50 text-sm mt-12 italic text-center top-[12px] mx-auto w-[320px]'>
                 {currentReview.note}
               </div>
             </div>


### PR DESCRIPTION
Currently some notes display too left, for example:

![note_display_left_before](https://github.com/djyde/wisetab/assets/69753389/7d2259a9-6637-4ecc-893f-216f998f3551)

This pr fixes this:

![note_display_center_after](https://github.com/djyde/wisetab/assets/69753389/a8910867-59c3-4e33-940b-3f2f96af2367)
